### PR TITLE
use reset for moo lexer, feed has been deprecated

### DIFF
--- a/nearley-moo.js
+++ b/nearley-moo.js
@@ -46,7 +46,7 @@ nm.parser = curry((nearley, grammar, lexer) => {
       let token
 
       // feed to moo
-      lexer.feed(str)
+      lexer.reset(str)
       while(token = lexer.next()) {
         // ignore tokens if asked!
         if (self.ignoredTokens.includes(token.type))


### PR DESCRIPTION
feed has been removed from the moo api, let's update this plz

[This is the release](https://github.com/tjvr/moo/releases/tag/v0.3) where the `feed` method has been removed.
 